### PR TITLE
Fix numeric virtual keyboard entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [1.0.1] Fixes numeric virtual keyboard entry
+
 ## [0.1.3] - Fixed Windows support
 
 * Fix for empty scan on Windows

--- a/lib/flutter_barcode_listener.dart
+++ b/lib/flutter_barcode_listener.dart
@@ -120,7 +120,7 @@ class _BarcodeKeyboardListenerState extends State<BarcodeKeyboardListener> {
       String? char = _getCharacterFromEvent(keyEvent);
       _controller.sink.add(char);
     }
-    return true;
+    return false;
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_barcode_listener
 description: Listen for any hardware barcode scanner without any manufacturer SDK
-version: 1.0.0
+version: 1.0.1
 publish_to: http://nexus.gojitsu.com:7777
 axlehire_project_type: package
 


### PR DESCRIPTION
For some reason Zebra's virtual numeric keyboard registers as a hardware keyboard. And the keyboard listener callback registered by this package returned `true` which prevented Flutter from receiving numeric input for any widget wrapped in a barcode listener widget.

Changing this to false allows this plugin to continue handling the text input but allows other listeners, including Flutter, to receive text input as well.